### PR TITLE
Baneslayer setup.sh update.  Requires --rpcuser and --rpcpassword sup…

### DIFF
--- a/scripts/debian/setup.sh
+++ b/scripts/debian/setup.sh
@@ -1,15 +1,18 @@
 #!/usr/bin/env sh
 
 isValidUsername() {
-  if echo $1 | grep -Eq '^[[:lower:]_][[:lower:][:digit:]_-]{2,15}$'; then
-    return 1
-  fi
-  return 0 
+    if echo $1 | grep -Eq '^[[:lower:]_][[:lower:][:digit:]_-]{2,15}$'; then
+        return 1
+    fi
+    return 0 
 }
 
+VERSION='0.1.0'
 REMOVE=false
 SYSTEMD=false
 RPCPORT=8545
+RPCUSER=
+RPCPASSWORD=
 SUCCESS=0
 
 for i in "$@"
@@ -27,15 +30,25 @@ case $i in
     -p=*|--rpcport=*)
     RPCPORT="${i#*=}"
     if ! $(echo $RPCPORT | grep -Eq '^[0-9]+$') ; then
-      echo "error: Provided RPC Port is not a number" >&2; exit 1
+        echo "error: Provided RPC Port is not a number" >&2; exit 1
     fi
     echo '-p or --rpcport option will only be used when -s or --systemd is provided'
+    shift # past argument=value
+    ;;
+    --rpcuser=*)
+    RPCUSER="${i#*=}"
+    shift # past argument=value
+    ;;
+    --rpcpassword=*)
+    RPCPASSWORD="${i#*=}"
     shift # past argument=value
     ;;
     -h|--help)
     echo '-r or --remove option will remove and reverse installation of the akroma masternode client'
     echo '-s or --systemd will create a systemd service for starting and stopping the masternode instance'
     echo '-p=port# or --rpcport=port# option to set specific port# for geth rpc to listen on (option will only be used if systemd service is created)'
+    echo '--rpcuser=user# option to set specific rpc user defined within Akroma dashboard (option will only be used if systemd service is created)'
+    echo '--rpcpassword=password# option to set specific rpc password defined within Akroma dashboard (option will only be used if systemd service is created)'
     echo '-u=user# or --user=user# option to set/create user to run geth (for default user "akroma" use only -u/--user)'
     exit 1
     ;;
@@ -44,8 +57,8 @@ case $i in
     CREATE_USER=true
     isValidUsername $USERNAME
     if [ "$?" -eq 0 ] ; then
-      echo 'Please provide valid username.'
-      exit 2
+        echo 'Please provide valid username.'
+        exit 2
     fi
     shift # past argument with no value
     ;;
@@ -64,11 +77,34 @@ if [ "$REMOVE" = true ]; then
 echo '=========================='
 echo 'Removing masternode installation...'
 echo '=========================='
+    if [ -f /etc/systemd/system/masternode.service ]; then
+        sudo systemctl stop masternode && sudo systemctl disable masternode && sudo rm /etc/systemd/system/masternode.service
+    fi
     if [ -f /etc/systemd/system/akromanode.service ]; then
         sudo systemctl stop akromanode && sudo systemctl disable akromanode && sudo rm /etc/systemd/system/akromanode.service
     fi
-    sudo rm /usr/sbin/geth
+    sudo rm -f /usr/sbin/geth
     exit 0
+fi
+
+if [ -z "$RPCUSER" ] || [ -z "$RPCPASSWORD" ]
+then
+    echo '--rpcuser and --rpcpassword must be defined.  You can obtain these from the Akroma dashboard for this MasterNode'
+    exit 2
+fi
+
+if [ "$CREATE_USER" = true ] ; then
+    echo '=========================='
+    echo "User configuration."
+    echo '=========================='
+
+    grep -q "$USERNAME" /etc/passwd
+    if [ $? -ne $SUCCESS ] ; then
+        echo "Creating user $USERNAME."
+        sudo adduser $USERNAME --gecos "" --disabled-password --system --group
+    else
+        echo "User $USERNAME found."
+    fi
 fi
 
 echo '=========================='
@@ -83,46 +119,34 @@ echo '=========================='
 # Download release zip for node
 arch=$(uname -m) 
 if [ "$arch" = 'x86_64' ]; then
-  wget https://github.com/akroma-project/akroma/releases/download/0.0.8/release.linux-amd64.0.0.8.zip
+    wget https://github.com/akroma-project/akroma/releases/download/$VERSION/release.linux-amd64.$VERSION.zip
 elif [ "$arch" = 'armv5l' ]; then
-  wget https://github.com/akroma-project/akroma/releases/download/0.0.8/release.linux-arm-5.0.0.8.zip
+    wget https://github.com/akroma-project/akroma/releases/download/$VERSION/release.linux-arm-5.$VERSION.zip
 elif [ "$arch" = 'armv6l' ]; then
-  wget https://github.com/akroma-project/akroma/releases/download/0.0.8/release.linux-arm-6.0.0.8.zip
+    wget https://github.com/akroma-project/akroma/releases/download/$VERSION/release.linux-arm-6.$VERSION.zip
 elif [ "$arch" = 'armv7l' ]; then
-  wget https://github.com/akroma-project/akroma/releases/download/0.0.8/release.linux-arm-7.0.0.8.zip
+    wget https://github.com/akroma-project/akroma/releases/download/$VERSION/release.linux-arm-7.$VERSION.zip
 elif [ "$arch" = 'armv8l' ]; then
-  wget https://github.com/akroma-project/akroma/releases/download/0.0.8/release.linux-arm-8.0.0.8.zip
+    wget https://github.com/akroma-project/akroma/releases/download/$VERSION/release.linux-arm-8.$VERSION.zip
 elif [ "$arch" = 'aarch64' ]; then
-  wget https://github.com/akroma-project/akroma/releases/download/0.0.8/release.linux-arm-64.0.0.8.zip
+    wget https://github.com/akroma-project/akroma/releases/download/$VERSION/release.linux-arm-64.$VERSION.zip
 else
-  wget https://github.com/akroma-project/akroma/releases/download/0.0.8/release.linux-386.0.0.8.zip
+    wget https://github.com/akroma-project/akroma/releases/download/$VERSION/release.linux-386.$VERSION.zip
 fi
 
 # Unzip release zip file
-unzip release.linux-*0.0.8.zip
+unzip -o release.linux-*$VERSION.zip
 
 # Make `geth` executable
 chmod +x geth
 
 # Cleanup
-rm release.linux-*0.0.8.zip
-
-if [ "$CREATE_USER" = true ] ; then
-  echo '=========================='
-  echo "User configuration."
-  echo '=========================='
-
-  grep -q "$USERNAME" /etc/passwd
-  if [ $? -ne $SUCCESS ] ; then 
-     echo "Creating user $USERNAME." 
-     sudo adduser $USERNAME --gecos "" --disabled-password
-  else 
-     echo "User $USERNAME found."
-  fi
-fi
-
+rm release.linux-*$VERSION.zip
 
 if [ "$SYSTEMD" = true ]; then
+    if [ -f /etc/systemd/system/masternode.service ]; then
+        sudo systemctl stop masternode && sudo systemctl disable masternode && sudo rm /etc/systemd/system/masternode.service
+    fi
     if [ -f /etc/systemd/system/akromanode.service ]; then
         sudo systemctl stop akromanode && sudo systemctl disable akromanode && sudo rm /etc/systemd/system/akromanode.service
     fi
@@ -139,7 +163,7 @@ After=network.target
 EOL
 
 if [ "$CREATE_USER" = true ] ; then
-  cat >> /tmp/akromanode.service << EOL
+    cat >> /tmp/akromanode.service << EOL
 User=${USERNAME}
 Group=${USERNAME}
 EOL
@@ -149,16 +173,16 @@ cat >> /tmp/akromanode.service << EOL
 Type=simple
 Restart=always
 RestartSec=30s
-ExecStart=/usr/sbin/geth --masternode --rpcport ${RPCPORT}
+ExecStart=/usr/sbin/geth --masternode --rpcport ${RPCPORT} --rpcuser ${RPCUSER} --rpcpassword ${RPCPASSWORD}
 
 [Install]
 WantedBy=default.target
 EOL
-        sudo mv /tmp/akromanode.service /etc/systemd/system
-        sudo cp geth /usr/sbin/
+        sudo \mv /tmp/akromanode.service /etc/systemd/system
+        sudo \cp geth /usr/sbin/
         systemctl status akromanode --no-pager --full
 else
-  echo 'systemd service will not be created.'
+    echo 'systemd service will not be created.'
 fi
 
 echo 'Done.'

--- a/scripts/debian/setup.sh
+++ b/scripts/debian/setup.sh
@@ -52,6 +52,7 @@ case $i in
     -h|--help)
     echo '-r or --remove option will remove and reverse installation of the akroma masternode client'
     echo '-s or --systemd will create a systemd service for starting and stopping the masternode instance'
+    echo '-m or --memory will use alternate memory manager for less memory usage and faster block syncs (USE AT YOUR OWN RISK!)'
     echo '-p=port# or --rpcport=port# option to set specific port# for geth rpc to listen on (option will only be used if systemd service is created)'
     echo '--rpcuser=user# option to set specific rpc user defined within Akroma dashboard (option will only be used if systemd service is created)'
     echo '--rpcpassword=password# option to set specific rpc password defined within Akroma dashboard (option will only be used if systemd service is created)'

--- a/scripts/rpm/setup.sh
+++ b/scripts/rpm/setup.sh
@@ -7,7 +7,8 @@ isValidUsername() {
     return 0 
 }
 
-VERSION='0.1.0'
+VERSION='0.1.1'
+MEMORY=false
 REMOVE=false
 SYSTEMD=false
 RPCPORT=8545
@@ -18,6 +19,11 @@ SUCCESS=0
 for i in "$@"
 do
 case $i in
+    -m|--memory)
+    MEMORY=true
+    break
+    shift # past argument=value
+    ;;
     -r|--remove)
     REMOVE=true
     break
@@ -119,6 +125,7 @@ echo '=========================='
 # Download release zip for node
 arch=$(uname -m) 
 if [ "$arch" = 'x86_64' ]; then
+    sudo yum install jemalloc -y
     wget https://github.com/akroma-project/akroma/releases/download/$VERSION/release.linux-amd64.$VERSION.zip
 elif [ "$arch" = 'armv5l' ]; then
     wget https://github.com/akroma-project/akroma/releases/download/$VERSION/release.linux-arm-5.$VERSION.zip
@@ -173,6 +180,15 @@ cat >> /tmp/akromanode.service << EOL
 Type=simple
 Restart=always
 RestartSec=30s
+EOL
+if [ "$MEMORY" = true ] && [ "$arch" = 'x86_64' ]
+then
+    cat >> /tmp/akromanode.service << EOL
+Environment="LD_PRELOAD=/usr/lib64/libjemalloc.so.1"
+EOL
+fi
+
+cat >> /tmp/akromanode.service << EOL
 ExecStart=/usr/sbin/geth --masternode --rpcport ${RPCPORT} --rpcuser ${RPCUSER} --rpcpassword ${RPCPASSWORD}
 
 [Install]

--- a/scripts/rpm/setup.sh
+++ b/scripts/rpm/setup.sh
@@ -1,15 +1,17 @@
 #!/usr/bin/env sh
 
 isValidUsername() {
-  if echo $1 | grep -Eq '^[[:lower:]_][[:lower:][:digit:]_-]{2,15}$'; then
-    return 1
-  fi
-  return 0 
+    if echo $1 | grep -Eq '^[[:lower:]_][[:lower:][:digit:]_-]{2,15}$'; then
+        return 1
+    fi
+    return 0 
 }
 
 REMOVE=false
 SYSTEMD=false
 RPCPORT=8545
+RPCUSER=
+RPCPASSWORD=
 SUCCESS=0
 
 for i in "$@"
@@ -27,15 +29,25 @@ case $i in
     -p=*|--rpcport=*)
     RPCPORT="${i#*=}"
     if ! $(echo $RPCPORT | grep -Eq '^[0-9]+$') ; then
-      echo "error: Provided RPC Port is not a number" >&2; exit 1
+        echo "error: Provided RPC Port is not a number" >&2; exit 1
     fi
     echo '-p or --rpcport option will only be used when -s or --systemd is provided'
+    shift # past argument=value
+    ;;
+    --rpcuser=*)
+    RPCUSER="${i#*=}"
+    shift # past argument=value
+    ;;
+    --rpcpassword=*)
+    RPCPASSWORD="${i#*=}"
     shift # past argument=value
     ;;
     -h|--help)
     echo '-r or --remove option will remove and reverse installation of the akroma masternode client'
     echo '-s or --systemd will create a systemd service for starting and stopping the masternode instance'
     echo '-p=port# or --rpcport=port# option to set specific port# for geth rpc to listen on (option will only be used if systemd service is created)'
+    echo '--rpcuser=user# option to set specific rpc user defined within Akroma dashboard (option will only be used if systemd service is created)'
+    echo '--rpcpassword=password# option to set specific rpc password defined within Akroma dashboard (option will only be used if systemd service is created)'
     echo '-u=user# or --user=user# option to set/create user to run geth (for default user "akroma" use only -u/--user)'
     exit 1
     ;;
@@ -44,8 +56,8 @@ case $i in
     CREATE_USER=true
     isValidUsername $USERNAME
     if [ "$?" -eq 0 ] ; then
-      echo 'Please provide valid username.'
-      exit 2
+        echo 'Please provide valid username.'
+        exit 2
     fi
     shift # past argument with no value
     ;;
@@ -64,11 +76,34 @@ if [ "$REMOVE" = true ]; then
 echo '=========================='
 echo 'Removing masternode installation...'
 echo '=========================='
+    if [ -f /etc/systemd/system/masternode.service ]; then
+        sudo systemctl stop masternode && sudo systemctl disable masternode && sudo rm /etc/systemd/system/masternode.service
+    fi
     if [ -f /etc/systemd/system/akromanode.service ]; then
         sudo systemctl stop akromanode && sudo systemctl disable akromanode && sudo rm /etc/systemd/system/akromanode.service
     fi
-    sudo rm /usr/sbin/geth
+    sudo rm -f /usr/sbin/geth
     exit 0
+fi
+
+if [ -z "$RPCUSER" ] || [ -z "$RPCPASSWORD" ]
+then
+    echo '--rpcuser and --rpcpassword must be defined.  You can obtain these from the Akroma dashboard for this MasterNode'
+    exit 2
+fi
+
+if [ "$CREATE_USER" = true ] ; then
+    echo '=========================='
+    echo "User configuration."
+    echo '=========================='
+
+    grep -q "$USERNAME" /etc/passwd
+    if [ $? -ne $SUCCESS ] ; then
+        echo "Creating user $USERNAME."
+        sudo adduser -r $USERNAME -s /bin/false -b /home -m
+    else
+        echo "User $USERNAME found."
+    fi
 fi
 
 echo '=========================='
@@ -83,46 +118,34 @@ echo '=========================='
 # Download release zip for node
 arch=$(uname -m) 
 if [ "$arch" = 'x86_64' ]; then
-  wget https://github.com/akroma-project/akroma/releases/download/0.0.8/release.linux-amd64.0.0.8.zip
+    wget https://github.com/akroma-project/akroma/releases/download/0.1.0/release.linux-amd64.0.1.0.zip
 elif [ "$arch" = 'armv5l' ]; then
-  wget https://github.com/akroma-project/akroma/releases/download/0.0.8/release.linux-arm-5.0.0.8.zip
+    wget https://github.com/akroma-project/akroma/releases/download/0.1.0/release.linux-arm-5.0.1.0.zip
 elif [ "$arch" = 'armv6l' ]; then
-  wget https://github.com/akroma-project/akroma/releases/download/0.0.8/release.linux-arm-6.0.0.8.zip
+    wget https://github.com/akroma-project/akroma/releases/download/0.1.0/release.linux-arm-6.0.1.0.zip
 elif [ "$arch" = 'armv7l' ]; then
-  wget https://github.com/akroma-project/akroma/releases/download/0.0.8/release.linux-arm-7.0.0.8.zip
+    wget https://github.com/akroma-project/akroma/releases/download/0.1.0/release.linux-arm-7.0.1.0.zip
 elif [ "$arch" = 'armv8l' ]; then
-  wget https://github.com/akroma-project/akroma/releases/download/0.0.8/release.linux-arm-8.0.0.8.zip
+    wget https://github.com/akroma-project/akroma/releases/download/0.1.0/release.linux-arm-8.0.1.0.zip
 elif [ "$arch" = 'aarch64' ]; then
-  wget https://github.com/akroma-project/akroma/releases/download/0.0.8/release.linux-arm-64.0.0.8.zip
+    wget https://github.com/akroma-project/akroma/releases/download/0.1.0/release.linux-arm-64.0.1.0.zip
 else
-  wget https://github.com/akroma-project/akroma/releases/download/0.0.8/release.linux-386.0.0.8.zip
+    wget https://github.com/akroma-project/akroma/releases/download/0.1.0/release.linux-386.0.1.0.zip
 fi
 
 # Unzip release zip file
-unzip release.linux-*0.0.8.zip
+unzip -o release.linux-*0.1.0.zip
 
 # Make `geth` executable
 chmod +x geth
 
 # Cleanup
-rm release.linux-*0.0.8.zip
-
-if [ "$CREATE_USER" = true ] ; then
-  echo '=========================='
-  echo "User configuration."
-  echo '=========================='
-
-  grep -q "$USERNAME" /etc/passwd
-  if [ $? -ne $SUCCESS ] ; then 
-     echo "Creating user $USERNAME." 
-     sudo adduser $USERNAME -s /bin/false
-  else 
-     echo "User $USERNAME found."
-  fi
-fi
-
+rm release.linux-*0.1.0.zip
 
 if [ "$SYSTEMD" = true ]; then
+    if [ -f /etc/systemd/system/masternode.service ]; then
+        sudo systemctl stop masternode && sudo systemctl disable masternode && sudo rm /etc/systemd/system/masternode.service
+    fi
     if [ -f /etc/systemd/system/akromanode.service ]; then
         sudo systemctl stop akromanode && sudo systemctl disable akromanode && sudo rm /etc/systemd/system/akromanode.service
     fi
@@ -139,7 +162,7 @@ After=network.target
 EOL
 
 if [ "$CREATE_USER" = true ] ; then
-  cat >> /tmp/akromanode.service << EOL
+    cat >> /tmp/akromanode.service << EOL
 User=${USERNAME}
 Group=${USERNAME}
 EOL
@@ -149,16 +172,16 @@ cat >> /tmp/akromanode.service << EOL
 Type=simple
 Restart=always
 RestartSec=30s
-ExecStart=/usr/sbin/geth --masternode --rpcport ${RPCPORT}
+ExecStart=/usr/sbin/geth --masternode --rpcport ${RPCPORT} --rpcuser ${RPCUSER} --rpcpassword ${RPCPASSWORD}
 
 [Install]
 WantedBy=default.target
 EOL
-        sudo mv /tmp/akromanode.service /etc/systemd/system
-        sudo cp geth /usr/sbin/
+        sudo \mv /tmp/akromanode.service /etc/systemd/system
+        sudo \cp geth /usr/sbin/
         systemctl status akromanode --no-pager --full
 else
-  echo 'systemd service will not be created.'
+    echo 'systemd service will not be created.'
 fi
 
 echo 'Done.'

--- a/scripts/rpm/setup.sh
+++ b/scripts/rpm/setup.sh
@@ -7,6 +7,7 @@ isValidUsername() {
     return 0 
 }
 
+VERSION='0.1.0'
 REMOVE=false
 SYSTEMD=false
 RPCPORT=8545
@@ -118,29 +119,29 @@ echo '=========================='
 # Download release zip for node
 arch=$(uname -m) 
 if [ "$arch" = 'x86_64' ]; then
-    wget https://github.com/akroma-project/akroma/releases/download/0.1.0/release.linux-amd64.0.1.0.zip
+    wget https://github.com/akroma-project/akroma/releases/download/$VERSION/release.linux-amd64.$VERSION.zip
 elif [ "$arch" = 'armv5l' ]; then
-    wget https://github.com/akroma-project/akroma/releases/download/0.1.0/release.linux-arm-5.0.1.0.zip
+    wget https://github.com/akroma-project/akroma/releases/download/$VERSION/release.linux-arm-5.$VERSION.zip
 elif [ "$arch" = 'armv6l' ]; then
-    wget https://github.com/akroma-project/akroma/releases/download/0.1.0/release.linux-arm-6.0.1.0.zip
+    wget https://github.com/akroma-project/akroma/releases/download/$VERSION/release.linux-arm-6.$VERSION.zip
 elif [ "$arch" = 'armv7l' ]; then
-    wget https://github.com/akroma-project/akroma/releases/download/0.1.0/release.linux-arm-7.0.1.0.zip
+    wget https://github.com/akroma-project/akroma/releases/download/$VERSION/release.linux-arm-7.$VERSION.zip
 elif [ "$arch" = 'armv8l' ]; then
-    wget https://github.com/akroma-project/akroma/releases/download/0.1.0/release.linux-arm-8.0.1.0.zip
+    wget https://github.com/akroma-project/akroma/releases/download/$VERSION/release.linux-arm-8.$VERSION.zip
 elif [ "$arch" = 'aarch64' ]; then
-    wget https://github.com/akroma-project/akroma/releases/download/0.1.0/release.linux-arm-64.0.1.0.zip
+    wget https://github.com/akroma-project/akroma/releases/download/$VERSION/release.linux-arm-64.$VERSION.zip
 else
-    wget https://github.com/akroma-project/akroma/releases/download/0.1.0/release.linux-386.0.1.0.zip
+    wget https://github.com/akroma-project/akroma/releases/download/$VERSION/release.linux-386.$VERSION.zip
 fi
 
 # Unzip release zip file
-unzip -o release.linux-*0.1.0.zip
+unzip -o release.linux-*$VERSION.zip
 
 # Make `geth` executable
 chmod +x geth
 
 # Cleanup
-rm release.linux-*0.1.0.zip
+rm release.linux-*$VERSION.zip
 
 if [ "$SYSTEMD" = true ]; then
     if [ -f /etc/systemd/system/masternode.service ]; then

--- a/scripts/rpm/setup.sh
+++ b/scripts/rpm/setup.sh
@@ -52,6 +52,7 @@ case $i in
     -h|--help)
     echo '-r or --remove option will remove and reverse installation of the akroma masternode client'
     echo '-s or --systemd will create a systemd service for starting and stopping the masternode instance'
+    echo '-m or --memory will use alternate memory manager for less memory usage and faster block syncs (USE AT YOUR OWN RISK!)'
     echo '-p=port# or --rpcport=port# option to set specific port# for geth rpc to listen on (option will only be used if systemd service is created)'
     echo '--rpcuser=user# option to set specific rpc user defined within Akroma dashboard (option will only be used if systemd service is created)'
     echo '--rpcpassword=password# option to set specific rpc password defined within Akroma dashboard (option will only be used if systemd service is created)'


### PR DESCRIPTION
Baneslayer setup.sh update.  Requires --rpcuser and --rpcpassword supplied on CLI.  Also:

If -u, not -u=*, then the akroma user is created as a system user at /home/akroma

If the old masternode.service is found, it'll recreate it as akromanode.service

Eliminate several overwrite prompts from unzip, mv, and cp